### PR TITLE
.flatten instead of .flatMap(x => x)

### DIFF
--- a/app/json/forexpressions.json
+++ b/app/json/forexpressions.json
@@ -28,7 +28,7 @@
     },
     {
       "preparagraph": "Using 'for' we can make more readable code",
-      "code": "val nums = List(List(1), List(2), List(3), List(4), List(5))\n\nval result = for {\n  numList <- nums\n  num <- numList\n  if(num%2 == 0)\n} yield(num)\n\nresult should be (__)\n\n// Which is the same as\n\nnums.flatMap(numList=>numList).filter(_%2==0) should be(result)\n",
+      "code": "val nums = List(List(1), List(2), List(3), List(4), List(5))\n\nval result = for {\n  numList <- nums\n  num <- numList\n  if(num%2 == 0)\n} yield(num)\n\nresult should be (__)\n\n// Which is the same as\nnums.flatMap(numList=>numList).filter(_%2==0) should be(result)\n\n// or the same as\nnums.flatten.filter(_%2==0) should be(result)\n",
       "solutions": [
         "List(2, 4)"
       ],


### PR DESCRIPTION
In the last part, I think is clearer to use

``` scala
nums.flatten.filter(_%2==0)
```

rather than 

``` scala
nums.flatMap(numList=>numList).filter(_%2==0)
```

I didn't replace that piece of code but added the flatten part at the end
